### PR TITLE
[v0.10][MCR v23][Backport] 4600 4602 4603 4604

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,14 @@ ARG CNI_VERSION=v1.1.0
 ARG STARGZ_SNAPSHOTTER_VERSION=v0.11.3
 
 ARG ALPINE_VERSION=3.15
+ARG XX_VERSION=1.3.0
 
 # git stage is used for checking out remote repository sources
 FROM --platform=$BUILDPLATFORM alpine:${ALPINE_VERSION} AS git
 RUN apk add --no-cache git
 
 # xx is a helper for cross-compilation
-FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.2.1 AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
 FROM --platform=$BUILDPLATFORM golang:1.18-alpine${ALPINE_VERSION} AS golatest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 
-ARG RUNC_VERSION=v1.0.2
+ARG RUNC_VERSION=v1.1.12
 ARG CONTAINERD_VERSION=v1.6.2
 # containerd v1.5 for integration tests
 ARG CONTAINERD_ALT_VERSION_15=v1.5.11

--- a/client/build_test.go
+++ b/client/build_test.go
@@ -63,7 +63,8 @@ func TestClientGatewayIntegration(t *testing.T) {
 	), integration.WithMirroredImages(integration.OfficialImages("busybox:latest")))
 
 	integration.Run(t, integration.TestFuncs(
-		testClientGatewayContainerSecurityMode,
+		testClientGatewayContainerSecurityModeCaps,
+		testClientGatewayContainerSecurityModeValidation,
 	), integration.WithMirroredImages(integration.OfficialImages("busybox:latest")),
 		integration.WithMatrix("secmode", map[string]interface{}{
 			"sandbox":  securitySandbox,
@@ -72,7 +73,8 @@ func TestClientGatewayIntegration(t *testing.T) {
 	)
 
 	integration.Run(t, integration.TestFuncs(
-		testClientGatewayContainerHostNetworking,
+		testClientGatewayContainerHostNetworkingAccess,
+		testClientGatewayContainerHostNetworkingValidation,
 	),
 		integration.WithMirroredImages(integration.OfficialImages("busybox:latest")),
 		integration.WithMatrix("netmode", map[string]interface{}{
@@ -1621,9 +1623,17 @@ func testClientGatewayExecFileActionError(t *testing.T, sb integration.Sandbox) 
 	checkAllReleasable(t, c, sb, true)
 }
 
-// testClientGatewayContainerSecurityMode ensures that the correct security mode
+// testClientGatewayContainerSecurityModeCaps ensures that the correct security mode
 // is propagated to the gateway container
-func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox) {
+func testClientGatewayContainerSecurityModeCaps(t *testing.T, sb integration.Sandbox) {
+	testClientGatewayContainerSecurityMode(t, sb, false)
+}
+
+func testClientGatewayContainerSecurityModeValidation(t *testing.T, sb integration.Sandbox) {
+	testClientGatewayContainerSecurityMode(t, sb, true)
+}
+
+func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox, expectFail bool) {
 	requiresLinux(t)
 
 	ctx := sb.Context()
@@ -1649,6 +1659,9 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 			require.EqualValues(t, 0xa80425fb, caps)
 		}
 		allowedEntitlements = []entitlements.Entitlement{}
+		if expectFail {
+			return
+		}
 	} else {
 		integration.SkipIfDockerd(t, sb)
 		assertCaps = func(caps uint64) {
@@ -1666,6 +1679,9 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 		}
 		mode = llb.SecurityModeInsecure
 		allowedEntitlements = []entitlements.Entitlement{entitlements.EntitlementSecurityInsecure}
+		if expectFail {
+			allowedEntitlements = []entitlements.Entitlement{}
+		}
 	}
 
 	b := func(ctx context.Context, c client.Client) (*client.Result, error) {
@@ -1715,6 +1731,12 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 		t.Logf("Stdout: %q", stdout.String())
 		t.Logf("Stderr: %q", stderr.String())
 
+		if expectFail {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "security.insecure is not allowed")
+			return nil, err
+		}
+
 		require.NoError(t, err)
 
 		capsValue, err := strconv.ParseUint(strings.TrimSpace(stdout.String()), 16, 64)
@@ -1729,7 +1751,13 @@ func testClientGatewayContainerSecurityMode(t *testing.T, sb integration.Sandbox
 		AllowedEntitlements: allowedEntitlements,
 	}
 	_, err = c.Build(ctx, solveOpts, product, b, nil)
-	require.NoError(t, err)
+
+	if expectFail {
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "security.insecure is not allowed")
+	} else {
+		require.NoError(t, err)
+	}
 
 	checkAllReleasable(t, c, sb, true)
 }
@@ -1805,7 +1833,15 @@ func testClientGatewayContainerExtraHosts(t *testing.T, sb integration.Sandbox) 
 	checkAllReleasable(t, c, sb, true)
 }
 
-func testClientGatewayContainerHostNetworking(t *testing.T, sb integration.Sandbox) {
+func testClientGatewayContainerHostNetworkingAccess(t *testing.T, sb integration.Sandbox) {
+	testClientGatewayContainerHostNetworking(t, sb, false)
+}
+
+func testClientGatewayContainerHostNetworkingValidation(t *testing.T, sb integration.Sandbox) {
+	testClientGatewayContainerHostNetworking(t, sb, true)
+}
+
+func testClientGatewayContainerHostNetworking(t *testing.T, sb integration.Sandbox, expectFail bool) {
 	if os.Getenv("BUILDKIT_RUN_NETWORK_INTEGRATION_TESTS") == "" {
 		t.SkipNow()
 	}
@@ -1826,6 +1862,9 @@ func testClientGatewayContainerHostNetworking(t *testing.T, sb integration.Sandb
 	if sb.Value("netmode") == hostNetwork {
 		netMode = pb.NetMode_HOST
 		allowedEntitlements = []entitlements.Entitlement{entitlements.EntitlementNetworkHost}
+		if expectFail {
+			allowedEntitlements = []entitlements.Entitlement{}
+		}
 	}
 	c, err := New(sb.Context(), sb.Address())
 	require.NoError(t, err)
@@ -1884,7 +1923,12 @@ func testClientGatewayContainerHostNetworking(t *testing.T, sb integration.Sandb
 		t.Logf("Stderr: %q", stderr.String())
 
 		if netMode == pb.NetMode_HOST {
-			require.NoError(t, err)
+			if expectFail {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "network.host is not allowed")
+			} else {
+				require.NoError(t, err)
+			}
 		} else {
 			require.Error(t, err)
 		}

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -636,8 +636,8 @@ func newController(c *cli.Context, cfg *config.Config) (*control.Controller, err
 		return nil, err
 	}
 	frontends := map[string]frontend.Frontend{}
-	frontends["dockerfile.v0"] = forwarder.NewGatewayForwarder(wc, dockerfile.Build)
-	frontends["gateway.v0"] = gateway.NewGatewayFrontend(wc)
+	frontends["dockerfile.v0"] = forwarder.NewGatewayForwarder(wc.Infos(), dockerfile.Build)
+	frontends["gateway.v0"] = gateway.NewGatewayFrontend(wc.Infos())
 
 	cacheStorage, err := bboltcachestorage.NewStore(filepath.Join(cfg.Root, "cache.db"))
 	if err != nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -6,7 +6,8 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/moby/buildkit/snapshot"
+	"github.com/containerd/containerd/mount"
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/solver/pb"
 )
 
@@ -25,8 +26,13 @@ type Meta struct {
 	SecurityMode   pb.SecurityMode
 }
 
+type MountableRef interface {
+	Mount() ([]mount.Mount, func() error, error)
+	IdentityMapping() *idtools.IdentityMapping
+}
+
 type Mountable interface {
-	Mount(ctx context.Context, readonly bool) (snapshot.Mountable, error)
+	Mount(ctx context.Context, readonly bool) (MountableRef, error)
 }
 
 type Mount struct {

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -213,12 +213,12 @@ func (s *submounts) subMount(m mount.Mount, subPath string) (mount.Mount, error)
 	}
 	h, err := hashstructure.Hash(m, hashstructure.FormatV2, nil)
 	if err != nil {
-		return mount.Mount{}, nil
+		return mount.Mount{}, err
 	}
 	if mr, ok := s.m[h]; ok {
 		sm, err := sub(mr.mount, subPath)
 		if err != nil {
-			return mount.Mount{}, nil
+			return mount.Mount{}, err
 		}
 		return sm, nil
 	}

--- a/executor/oci/spec.go
+++ b/executor/oci/spec.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
-	"github.com/containerd/continuity/fs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/moby/buildkit/executor"
@@ -198,6 +197,7 @@ func GenerateSpec(ctx context.Context, meta executor.Meta, mounts []executor.Mou
 type mountRef struct {
 	mount   mount.Mount
 	unmount func() error
+	subRefs map[string]mountRef
 }
 
 type submounts struct {
@@ -216,9 +216,16 @@ func (s *submounts) subMount(m mount.Mount, subPath string) (mount.Mount, error)
 		return mount.Mount{}, err
 	}
 	if mr, ok := s.m[h]; ok {
-		sm, err := sub(mr.mount, subPath)
+		if sm, ok := mr.subRefs[subPath]; ok {
+			return sm.mount, nil
+		}
+		sm, unmount, err := sub(mr.mount, subPath)
 		if err != nil {
 			return mount.Mount{}, err
+		}
+		mr.subRefs[subPath] = mountRef{
+			mount:   sm,
+			unmount: unmount,
 		}
 		return sm, nil
 	}
@@ -244,11 +251,16 @@ func (s *submounts) subMount(m mount.Mount, subPath string) (mount.Mount, error)
 			Options: opts,
 		},
 		unmount: lm.Unmount,
+		subRefs: map[string]mountRef{},
 	}
 
-	sm, err := sub(s.m[h].mount, subPath)
+	sm, unmount, err := sub(s.m[h].mount, subPath)
 	if err != nil {
 		return mount.Mount{}, err
+	}
+	s.m[h].subRefs[subPath] = mountRef{
+		mount:   sm,
+		unmount: unmount,
 	}
 	return sm, nil
 }
@@ -259,21 +271,15 @@ func (s *submounts) cleanup() {
 	for _, m := range s.m {
 		func(m mountRef) {
 			go func() {
+				for _, sm := range m.subRefs {
+					sm.unmount()
+				}
 				m.unmount()
 				wg.Done()
 			}()
 		}(m)
 	}
 	wg.Wait()
-}
-
-func sub(m mount.Mount, subPath string) (mount.Mount, error) {
-	src, err := fs.RootPath(m.Source, subPath)
-	if err != nil {
-		return mount.Mount{}, err
-	}
-	m.Source = src
-	return m, nil
 }
 
 func specMapping(s []idtools.IDMap) []specs.LinuxIDMapping {

--- a/executor/oci/spec_freebsd.go
+++ b/executor/oci/spec_freebsd.go
@@ -1,0 +1,15 @@
+package oci
+
+import (
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/continuity/fs"
+)
+
+func sub(m mount.Mount, subPath string) (mount.Mount, func() error, error) {
+	src, err := fs.RootPath(m.Source, subPath)
+	if err != nil {
+		return mount.Mount{}, nil, err
+	}
+	m.Source = src
+	return m, func() error { return nil }, nil
+}

--- a/executor/oci/spec_linux.go
+++ b/executor/oci/spec_linux.go
@@ -1,0 +1,57 @@
+//go:build linux
+// +build linux
+
+package oci
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/continuity/fs"
+	"github.com/moby/buildkit/snapshot"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+func sub(m mount.Mount, subPath string) (mount.Mount, func() error, error) {
+	var retries = 10
+	root := m.Source
+	for {
+		src, err := fs.RootPath(root, subPath)
+		if err != nil {
+			return mount.Mount{}, nil, err
+		}
+		// similar to runc.WithProcfd
+		fh, err := os.OpenFile(src, unix.O_PATH|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return mount.Mount{}, nil, err
+		}
+
+		fdPath := "/proc/self/fd/" + strconv.Itoa(int(fh.Fd()))
+		if resolved, err := os.Readlink(fdPath); err != nil {
+			fh.Close()
+			return mount.Mount{}, nil, err
+		} else if resolved != src {
+			retries--
+			if retries <= 0 {
+				fh.Close()
+				return mount.Mount{}, nil, errors.Errorf("unable to safely resolve subpath %s", subPath)
+			}
+			fh.Close()
+			continue
+		}
+
+		m.Source = fdPath
+		lm := snapshot.LocalMounterWithMounts([]mount.Mount{m}, snapshot.ForceRemount())
+		mp, err := lm.Mount()
+		if err != nil {
+			fh.Close()
+			return mount.Mount{}, nil, err
+		}
+		m.Source = mp
+		fh.Close() // release the fd, we don't need it anymore
+
+		return m, lm.Unmount, nil
+	}
+}

--- a/executor/oci/spec_windows.go
+++ b/executor/oci/spec_windows.go
@@ -4,7 +4,9 @@
 package oci
 
 import (
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/continuity/fs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/pkg/errors"
@@ -42,4 +44,13 @@ func generateRlimitOpts(ulimits []*pb.Ulimit) ([]oci.SpecOpts, error) {
 		return nil, nil
 	}
 	return nil, errors.New("no support for POSIXRlimit on Windows")
+}
+
+func sub(m mount.Mount, subPath string) (mount.Mount, func() error, error) {
+	src, err := fs.RootPath(m.Source, subPath)
+	if err != nil {
+		return mount.Mount{}, nil, err
+	}
+	m.Source = src
+	return m, func() error { return nil }, nil
 }

--- a/executor/stubs.go
+++ b/executor/stubs.go
@@ -42,9 +42,18 @@ func MountStubsCleaner(dir string, mounts []Mount) func() {
 			if err != nil {
 				continue
 			}
-			if st.Size() != 0 {
+			if st.IsDir() {
+				entries, err := os.ReadDir(p)
+				if err != nil {
+					continue
+				}
+				if len(entries) != 0 {
+					continue
+				}
+			} else if st.Size() != 0 {
 				continue
 			}
+
 			// Back up the timestamps of the dir for reproducible builds
 			// https://github.com/moby/buildkit/issues/3148
 			dir := filepath.Dir(p)

--- a/executor/stubs.go
+++ b/executor/stubs.go
@@ -7,6 +7,8 @@ import (
 	"syscall"
 
 	"github.com/containerd/continuity/fs"
+	"github.com/moby/buildkit/util/system"
+	"github.com/sirupsen/logrus"
 )
 
 func MountStubsCleaner(dir string, mounts []Mount) func() {
@@ -43,7 +45,29 @@ func MountStubsCleaner(dir string, mounts []Mount) func() {
 			if st.Size() != 0 {
 				continue
 			}
-			os.Remove(p)
+			// Back up the timestamps of the dir for reproducible builds
+			// https://github.com/moby/buildkit/issues/3148
+			dir := filepath.Dir(p)
+			dirSt, err := os.Stat(dir)
+			if err != nil {
+				logrus.WithError(err).Warnf("Failed to stat %q (parent of mount stub %q)", dir, p)
+				continue
+			}
+			mtime := dirSt.ModTime()
+			atime, err := system.Atime(dirSt)
+			if err != nil {
+				logrus.WithError(err).Warnf("Failed to stat atime of %q (parent of mount stub %q)", dir, p)
+				atime = mtime
+			}
+
+			if err := os.Remove(p); err != nil {
+				logrus.WithError(err).Warnf("Failed to remove mount stub %q", p)
+			}
+
+			// Restore the timestamps of the dir
+			if err := os.Chtimes(dir, atime, mtime); err != nil {
+				logrus.WithError(err).Warnf("Failed to restore time time mount stub timestamp (os.Chtimes(%q, %v, %v))", dir, atime, mtime)
+			}
 		}
 	}
 }

--- a/executor/stubs.go
+++ b/executor/stubs.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/containerd/continuity/fs"
@@ -38,6 +39,11 @@ func MountStubsCleaner(dir string, mounts []Mount) func() {
 
 	return func() {
 		for _, p := range paths {
+			p, err := fs.RootPath(dir, strings.TrimPrefix(p, dir))
+			if err != nil {
+				continue
+			}
+
 			st, err := os.Lstat(p)
 			if err != nil {
 				continue
@@ -56,8 +62,12 @@ func MountStubsCleaner(dir string, mounts []Mount) func() {
 
 			// Back up the timestamps of the dir for reproducible builds
 			// https://github.com/moby/buildkit/issues/3148
-			dir := filepath.Dir(p)
-			dirSt, err := os.Stat(dir)
+			parent := filepath.Dir(p)
+			if realPath, err := fs.RootPath(dir, strings.TrimPrefix(parent, dir)); err != nil || realPath != parent {
+				continue
+			}
+
+			dirSt, err := os.Stat(parent)
 			if err != nil {
 				logrus.WithError(err).Warnf("Failed to stat %q (parent of mount stub %q)", dir, p)
 				continue
@@ -74,7 +84,7 @@ func MountStubsCleaner(dir string, mounts []Mount) func() {
 			}
 
 			// Restore the timestamps of the dir
-			if err := os.Chtimes(dir, atime, mtime); err != nil {
+			if err := os.Chtimes(parent, atime, mtime); err != nil {
 				logrus.WithError(err).Warnf("Failed to restore time time mount stub timestamp (os.Chtimes(%q, %v, %v))", dir, atime, mtime)
 			}
 		}

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/executor"
 	gw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/solver/pb"
@@ -11,7 +12,7 @@ import (
 )
 
 type Frontend interface {
-	Solve(ctx context.Context, llb FrontendLLBBridge, opt map[string]string, inputs map[string]*pb.Definition, sid string, sm *session.Manager) (*Result, error)
+	Solve(ctx context.Context, llb FrontendLLBBridge, exec executor.Executor, opt map[string]string, inputs map[string]*pb.Definition, sid string, sm *session.Manager) (*Result, error)
 }
 
 type FrontendLLBBridge interface {

--- a/frontend/gateway/container.go
+++ b/frontend/gateway/container.go
@@ -43,7 +43,7 @@ type Mount struct {
 	WorkerRef *worker.WorkerRef
 }
 
-func NewContainer(ctx context.Context, w worker.Worker, sm *session.Manager, g session.Group, req NewContainerRequest) (client.Container, error) {
+func NewContainer(ctx context.Context, cm cache.Manager, exec executor.Executor, sm *session.Manager, g session.Group, req NewContainerRequest) (client.Container, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	platform := opspb.Platform{
@@ -58,7 +58,7 @@ func NewContainer(ctx context.Context, w worker.Worker, sm *session.Manager, g s
 		netMode:    req.NetMode,
 		extraHosts: req.ExtraHosts,
 		platform:   platform,
-		executor:   w.Executor(),
+		executor:   exec,
 		errGroup:   eg,
 		ctx:        ctx,
 		cancel:     cancel,
@@ -79,9 +79,8 @@ func NewContainer(ctx context.Context, w worker.Worker, sm *session.Manager, g s
 	}
 
 	name := fmt.Sprintf("container %s", req.ContainerID)
-	mm := mounts.NewMountManager(name, w.CacheManager(), sm)
-	p, err := PrepareMounts(ctx, mm, w.CacheManager(), g, "", mnts, refs, func(m *opspb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
-		cm := w.CacheManager()
+	mm := mounts.NewMountManager(name, cm, sm)
+	p, err := PrepareMounts(ctx, mm, cm, g, "", mnts, refs, func(m *opspb.Mount, ref cache.ImmutableRef) (cache.MutableRef, error) {
 		if m.Input != opspb.Empty {
 			cm = refs[m.Input].Worker.CacheManager()
 		}

--- a/frontend/gateway/forwarder/frontend.go
+++ b/frontend/gateway/forwarder/frontend.go
@@ -3,6 +3,7 @@ package forwarder
 import (
 	"context"
 
+	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/frontend"
 	"github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
@@ -22,8 +23,8 @@ type GatewayForwarder struct {
 	f       client.BuildFunc
 }
 
-func (gf *GatewayForwarder) Solve(ctx context.Context, llbBridge frontend.FrontendLLBBridge, opts map[string]string, inputs map[string]*pb.Definition, sid string, sm *session.Manager) (retRes *frontend.Result, retErr error) {
-	c, err := llbBridgeToGatewayClient(ctx, llbBridge, opts, inputs, gf.workers, sid, sm)
+func (gf *GatewayForwarder) Solve(ctx context.Context, llbBridge frontend.FrontendLLBBridge, exec executor.Executor, opts map[string]string, inputs map[string]*pb.Definition, sid string, sm *session.Manager) (retRes *frontend.Result, retErr error) {
+	c, err := llbBridgeToGatewayClient(ctx, llbBridge, exec, opts, inputs, gf.workers, sid, sm)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/gateway/gateway.go
+++ b/frontend/gateway/gateway.go
@@ -83,7 +83,7 @@ func filterPrefix(opts map[string]string, pfx string) map[string]string {
 	return m
 }
 
-func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.FrontendLLBBridge, opts map[string]string, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*frontend.Result, error) {
+func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.FrontendLLBBridge, exec executor.Executor, opts map[string]string, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*frontend.Result, error) {
 	source, ok := opts[keySource]
 	if !ok {
 		return nil, errors.Errorf("no source specified for gateway")
@@ -251,17 +251,12 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 		}
 	}
 
-	lbf, ctx, err := serveLLBBridgeForwarder(ctx, llbBridge, gf.workers, inputs, sid, sm)
+	lbf, ctx, err := serveLLBBridgeForwarder(ctx, llbBridge, exec, gf.workers, inputs, sid, sm)
 	defer lbf.conn.Close() //nolint
 	if err != nil {
 		return nil, err
 	}
 	defer lbf.Discard()
-
-	w, err := gf.workers.GetDefault()
-	if err != nil {
-		return nil, err
-	}
 
 	mdmnt, release, err := metadataMount(frontendDef)
 	if err != nil {
@@ -275,8 +270,7 @@ func (gf *gatewayFrontend) Solve(ctx context.Context, llbBridge frontend.Fronten
 		mnts = append(mnts, *mdmnt)
 	}
 
-	err = w.Executor().Run(ctx, "", mountWithSession(rootFS, session.NewGroup(sid)), mnts, executor.ProcessInfo{Meta: meta, Stdin: lbf.Stdin, Stdout: lbf.Stdout, Stderr: os.Stderr}, nil)
-
+	err = exec.Run(ctx, "", mountWithSession(rootFS, session.NewGroup(sid)), mnts, executor.ProcessInfo{Meta: meta, Stdin: lbf.Stdin, Stdout: lbf.Stdout, Stderr: os.Stderr}, nil)
 	if err != nil {
 		if errdefs.IsCanceled(ctx, err) && lbf.isErrServerClosed {
 			err = errors.Errorf("frontend grpc server closed unexpectedly")
@@ -411,11 +405,11 @@ func (lbf *llbBridgeForwarder) Result() (*frontend.Result, error) {
 	return lbf.result, nil
 }
 
-func NewBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) LLBBridgeForwarder {
-	return newBridgeForwarder(ctx, llbBridge, workers, inputs, sid, sm)
+func NewBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, exec executor.Executor, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) LLBBridgeForwarder {
+	return newBridgeForwarder(ctx, llbBridge, exec, workers, inputs, sid, sm)
 }
 
-func newBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) *llbBridgeForwarder {
+func newBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, exec executor.Executor, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) *llbBridgeForwarder {
 	lbf := &llbBridgeForwarder{
 		callCtx:       ctx,
 		llbBridge:     llbBridge,
@@ -428,13 +422,14 @@ func newBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridg
 		sid:           sid,
 		sm:            sm,
 		ctrs:          map[string]gwclient.Container{},
+		executor:      exec,
 	}
 	return lbf
 }
 
-func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*llbBridgeForwarder, context.Context, error) {
+func serveLLBBridgeForwarder(ctx context.Context, llbBridge frontend.FrontendLLBBridge, exec executor.Executor, workers worker.Infos, inputs map[string]*opspb.Definition, sid string, sm *session.Manager) (*llbBridgeForwarder, context.Context, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	lbf := newBridgeForwarder(ctx, llbBridge, workers, inputs, sid, sm)
+	lbf := newBridgeForwarder(ctx, llbBridge, exec, workers, inputs, sid, sm)
 	server := grpc.NewServer(grpc.UnaryInterceptor(grpcerrors.UnaryServerInterceptor), grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor))
 	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
 	pb.RegisterLLBBridgeServer(server, lbf)
@@ -529,6 +524,7 @@ type llbBridgeForwarder struct {
 	isErrServerClosed bool
 	sid               string
 	sm                *session.Manager
+	executor          executor.Executor
 	*pipe
 	ctrs   map[string]gwclient.Container
 	ctrsMu sync.Mutex
@@ -977,7 +973,7 @@ func (lbf *llbBridgeForwarder) NewContainer(ctx context.Context, in *pb.NewConta
 	// and we want the context to live for the duration of the container.
 	group := session.NewGroup(lbf.sid)
 
-	w, err := lbf.workers.GetDefault()
+	cm, err := lbf.workers.DefaultCacheManager()
 	if err != nil {
 		return nil, stack.Enable(err)
 	}
@@ -987,7 +983,7 @@ func (lbf *llbBridgeForwarder) NewContainer(ctx context.Context, in *pb.NewConta
 		return nil, stack.Enable(err)
 	}
 
-	ctr, err := NewContainer(context.Background(), w, lbf.sm, group, ctrReq)
+	ctr, err := NewContainer(context.Background(), cm, lbf.executor, lbf.sm, group, ctrReq)
 	if err != nil {
 		return nil, stack.Enable(err)
 	}

--- a/snapshot/localmounter_unix.go
+++ b/snapshot/localmounter_unix.go
@@ -4,8 +4,8 @@
 package snapshot
 
 import (
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"github.com/containerd/containerd/mount"
@@ -25,30 +25,48 @@ func (lm *localMounter) Mount() (string, error) {
 		lm.release = release
 	}
 
+	var isFile bool
 	if len(lm.mounts) == 1 && (lm.mounts[0].Type == "bind" || lm.mounts[0].Type == "rbind") {
-		ro := false
-		for _, opt := range lm.mounts[0].Options {
-			if opt == "ro" {
-				ro = true
-				break
+		if !lm.forceRemount {
+			ro := false
+			for _, opt := range lm.mounts[0].Options {
+				if opt == "ro" {
+					ro = true
+					break
+				}
+			}
+			if !ro {
+				return lm.mounts[0].Source, nil
 			}
 		}
-		if !ro {
-			return lm.mounts[0].Source, nil
+		fi, err := os.Stat(lm.mounts[0].Source)
+		if err != nil {
+			return "", err
+		}
+		if !fi.IsDir() {
+			isFile = true
 		}
 	}
 
-	dir, err := ioutil.TempDir("", "buildkit-mount")
+	dest, err := os.MkdirTemp("", "buildkit-mount")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}
 
-	if err := mount.All(lm.mounts, dir); err != nil {
-		os.RemoveAll(dir)
-		return "", errors.Wrapf(err, "failed to mount %s: %+v", dir, lm.mounts)
+	if isFile {
+		dest = filepath.Join(dest, "file")
+		if err := os.WriteFile(dest, []byte{}, 0644); err != nil {
+			os.RemoveAll(dest)
+			return "", errors.Wrap(err, "failed to create temp file")
+		}
 	}
-	lm.target = dir
-	return dir, nil
+
+	if err := mount.All(lm.mounts, dest); err != nil {
+		os.RemoveAll(dest)
+		return "", errors.Wrapf(err, "failed to mount %s: %+v", dest, lm.mounts)
+	}
+	lm.target = dest
+	return dest, nil
 }
 
 func (lm *localMounter) Unmount() error {

--- a/snapshot/snapshotter.go
+++ b/snapshot/snapshotter.go
@@ -10,14 +10,11 @@ import (
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/buildkit/executor"
 	"github.com/pkg/errors"
 )
 
-type Mountable interface {
-	// ID() string
-	Mount() ([]mount.Mount, func() error, error)
-	IdentityMapping() *idtools.IdentityMapping
-}
+type Mountable = executor.MountableRef
 
 // Snapshotter defines interface that any snapshot implementation should satisfy
 type Snapshotter interface {

--- a/solver/llbsolver/bridge.go
+++ b/solver/llbsolver/bridge.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/buildinfo"
+	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/flightcontrol"
 	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/worker"
@@ -140,6 +141,18 @@ func (b *llbBridge) loadResult(ctx context.Context, def *pb.Definition, cacheImp
 	return res, bi, nil
 }
 
+func (b *llbBridge) validateEntitlements(p executor.ProcessInfo) error {
+	ent, err := loadEntitlements(b.builder)
+	if err != nil {
+		return err
+	}
+	v := entitlements.Values{
+		NetworkHost:      p.Meta.NetMode == pb.NetMode_HOST,
+		SecurityInsecure: p.Meta.SecurityMode == pb.SecurityMode_INSECURE,
+	}
+	return ent.Check(v)
+}
+
 func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid string) (res *frontend.Result, err error) {
 	if req.Definition != nil && req.Definition.Def != nil && req.Frontend != "" {
 		return nil, errors.New("cannot solve with both Definition and Frontend specified")
@@ -193,6 +206,10 @@ func (b *llbBridge) Solve(ctx context.Context, req frontend.SolveRequest, sid st
 }
 
 func (b *llbBridge) Run(ctx context.Context, id string, rootfs executor.Mount, mounts []executor.Mount, process executor.ProcessInfo, started chan<- struct{}) error {
+	if err := b.validateEntitlements(process); err != nil {
+		return err
+	}
+
 	if err := b.loadExecutor(); err != nil {
 		return err
 	}
@@ -200,6 +217,10 @@ func (b *llbBridge) Run(ctx context.Context, id string, rootfs executor.Mount, m
 }
 
 func (b *llbBridge) Exec(ctx context.Context, id string, process executor.ProcessInfo) error {
+	if err := b.validateEntitlements(process); err != nil {
+		return err
+	}
+
 	if err := b.loadExecutor(); err != nil {
 		return err
 	}

--- a/solver/llbsolver/vertex.go
+++ b/solver/llbsolver/vertex.go
@@ -99,16 +99,12 @@ func ValidateEntitlements(ent entitlements.Set) LoadOpt {
 	return func(op *pb.Op, _ *pb.OpMetadata, opt *solver.VertexOptions) error {
 		switch op := op.Op.(type) {
 		case *pb.Op_Exec:
-			if op.Exec.Network == pb.NetMode_HOST {
-				if !ent.Allowed(entitlements.EntitlementNetworkHost) {
-					return errors.Errorf("%s is not allowed", entitlements.EntitlementNetworkHost)
-				}
+			v := entitlements.Values{
+				NetworkHost:      op.Exec.Network == pb.NetMode_HOST,
+				SecurityInsecure: op.Exec.Security == pb.SecurityMode_INSECURE,
 			}
-
-			if op.Exec.Security == pb.SecurityMode_INSECURE {
-				if !ent.Allowed(entitlements.EntitlementSecurityInsecure) {
-					return errors.Errorf("%s is not allowed", entitlements.EntitlementSecurityInsecure)
-				}
+			if err := ent.Check(v); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/util/entitlements/entitlements.go
+++ b/util/entitlements/entitlements.go
@@ -58,3 +58,23 @@ func (s Set) Allowed(e Entitlement) bool {
 	_, ok := s[e]
 	return ok
 }
+
+func (s Set) Check(v Values) error {
+	if v.NetworkHost {
+		if !s.Allowed(EntitlementNetworkHost) {
+			return errors.Errorf("%s is not allowed", EntitlementNetworkHost)
+		}
+	}
+
+	if v.SecurityInsecure {
+		if !s.Allowed(EntitlementSecurityInsecure) {
+			return errors.Errorf("%s is not allowed", EntitlementSecurityInsecure)
+		}
+	}
+	return nil
+}
+
+type Values struct {
+	NetworkHost      bool
+	SecurityInsecure bool
+}

--- a/util/system/atime_unix.go
+++ b/util/system/atime_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+// +build !windows
+
+package system
+
+import (
+	"fmt"
+	iofs "io/fs"
+	"syscall"
+	"time"
+
+	"github.com/containerd/continuity/fs"
+)
+
+func Atime(st iofs.FileInfo) (time.Time, error) {
+	stSys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
+	}
+	return fs.StatATimeAsTime(stSys), nil
+}

--- a/util/system/atime_unix.go
+++ b/util/system/atime_unix.go
@@ -4,18 +4,18 @@
 package system
 
 import (
-	"fmt"
 	iofs "io/fs"
 	"syscall"
 	"time"
 
 	"github.com/containerd/continuity/fs"
+	"github.com/pkg/errors"
 )
 
 func Atime(st iofs.FileInfo) (time.Time, error) {
 	stSys, ok := st.Sys().(*syscall.Stat_t)
 	if !ok {
-		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
+		return time.Time{}, errors.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
 	}
 	return fs.StatATimeAsTime(stSys), nil
 }

--- a/util/system/atime_windows.go
+++ b/util/system/atime_windows.go
@@ -1,0 +1,17 @@
+package system
+
+import (
+	"fmt"
+	iofs "io/fs"
+	"syscall"
+	"time"
+)
+
+func Atime(st iofs.FileInfo) (time.Time, error) {
+	stSys, ok := st.Sys().(*syscall.Win32FileAttributeData)
+	if !ok {
+		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Win32FileAttributeData, got %T", st.Sys())
+	}
+	// ref: https://github.com/golang/go/blob/go1.19.2/src/os/types_windows.go#L230
+	return time.Unix(0, stSys.LastAccessTime.Nanoseconds()), nil
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -38,6 +38,6 @@ type Worker interface {
 }
 
 type Infos interface {
-	GetDefault() (Worker, error)
+	DefaultCacheManager() (cache.Manager, error)
 	WorkerInfos() []client.WorkerInfo
 }

--- a/worker/workercontroller.go
+++ b/worker/workercontroller.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"github.com/containerd/containerd/filters"
+	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/client"
 	"github.com/pkg/errors"
 )
@@ -68,4 +69,26 @@ func (c *Controller) WorkerInfos() []client.WorkerInfo {
 		})
 	}
 	return out
+}
+
+func (c *Controller) Infos() Infos {
+	return &infosController{c: c}
+}
+
+type infosController struct {
+	c *Controller
+}
+
+var _ Infos = &infosController{}
+
+func (c *infosController) DefaultCacheManager() (cache.Manager, error) {
+	w, err := c.c.GetDefault()
+	if err != nil {
+		return nil, err
+	}
+	return w.CacheManager(), nil
+}
+
+func (c *infosController) WorkerInfos() []client.WorkerInfo {
+	return c.c.WorkerInfos()
 }


### PR DESCRIPTION
Backport of CVE fixes:
[4600](https://github.com/moby/buildkit/pull/4600) - [CVE-2024-21626](https://www.cve.org/CVERecord?id=CVE-2024-21626) [GHSA-xr7r-f8xq-vfvv](https://github.com/advisories/GHSA-xr7r-f8xq-vfvv)
[4602](https://github.com/moby/buildkit/pull/4602) - [CVE-2024-23653](https://www.cve.org/CVERecord?id=CVE-2024-23653) [GHSA-wr6v-9f75-vh2g](https://github.com/moby/buildkit/security/advisories/GHSA-wr6v-9f75-vh2g)
[4603](https://github.com/moby/buildkit/pull/4603) - [CVE-2024-23652](https://www.cve.org/CVERecord?id=CVE-2024-23652)  [GHSA-4v98-7qmw-rqr8](https://github.com/moby/buildkit/security/advisories/GHSA-4v98-7qmw-rqr8)
[4604](https://github.com/moby/buildkit/pull/4604) - [CVE-2024-23651](https://www.cve.org/CVERecord?id=CVE-2024-23651) [GHSA-m3r6-h7wv-7xxv](https://github.com/moby/buildkit/security/advisories/GHSA-m3r6-h7wv-7xxv)

Backports of refactoring for smooth application CVE fixes:
[MountStubsCleaner: preserve timestamps - 0b5a315 ](https://github.com/Mirantis/buildkit/commit/0b5a315c221e18eca0ecec4a97f411fcf9b64a74)
[executor: stubs cleaner should remove empty directory mounts - 6778973](https://github.com/Mirantis/buildkit/commit/67789737769f02861d9b4d5a2ec5e14d4e490a29)
[chore: tidy atime_unix.go to use errors pkg - 32b5e4d](https://github.com/Mirantis/buildkit/commit/32b5e4dacf083ad1b26d4458558641a2a7196db6)


Fix **cross** tests for **ppc64le**
[Dockerfile: update xx to 1.3.0 - 5955cc](https://github.com/Mirantis/buildkit/commit/5955ccf77c3618970d336821fd75857155f9b6b9)