### PR TITLE
[v0.12 backport] security: path traversal and git option injection fixes

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -174,7 +174,7 @@ jobs:
       -
         name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: ./bin/testreports

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -91,7 +91,7 @@ jobs:
             });
       -
         name: Build
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v5
         with:
           targets: integration-tests-base
           set: |

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -132,7 +132,7 @@ jobs:
           CACHE_TO: type=gha,scope=binaries-${{ env.PLATFORM_PAIR }}
       -
         name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: buildkit
           path: ${{ env.DESTDIR }}/*
@@ -193,7 +193,7 @@ jobs:
     steps:
       -
         name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: buildkit
           path: ${{ env.DESTDIR }}

--- a/.github/workflows/dockerd.yml
+++ b/.github/workflows/dockerd.yml
@@ -63,7 +63,7 @@ jobs:
           wget -qO- "https://download.docker.com/linux/static/stable/x86_64/docker-${{ env.DOCKER_VERSION }}.tgz" | tar xvz --strip 1
       -
         name: Upload dockerd
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dockerd
           path: /tmp/moby/dockerd
@@ -109,7 +109,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Download dockerd
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dockerd
           path: ./build/

--- a/.github/workflows/test-os.yml
+++ b/.github/workflows/test-os.yml
@@ -81,7 +81,7 @@ jobs:
       -
         name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: ./bin/testreports

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,6 +55,6 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Validate
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v5
         with:
           targets: ${{ matrix.target }}

--- a/executor/containerdexecutor/executor.go
+++ b/executor/containerdexecutor/executor.go
@@ -83,6 +83,9 @@ func (w *containerdExecutor) Run(ctx context.Context, id string, root executor.M
 	if id == "" {
 		id = identity.NewID()
 	}
+	if err := executor.ValidContainerID(id); err != nil {
+		return nil, err
+	}
 
 	startedOnce := sync.Once{}
 	done := make(chan error, 1)

--- a/executor/containerid.go
+++ b/executor/containerid.go
@@ -1,0 +1,18 @@
+package executor
+
+import "github.com/pkg/errors"
+
+// ValidContainerID validates that id is non-empty and contains only ASCII letters and digits.
+func ValidContainerID(id string) error {
+	if id == "" {
+		return errors.New("container id must not be empty")
+	}
+	for i := 0; i < len(id); i++ {
+		ch := id[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+			continue
+		}
+		return errors.Errorf("invalid container id %q: only letters and numbers are allowed", id)
+	}
+	return nil
+}

--- a/executor/containerid_test.go
+++ b/executor/containerid_test.go
@@ -1,0 +1,33 @@
+package executor
+
+import "testing"
+
+func TestValidContainerID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{name: "lowercase", id: "abc123", wantErr: false},
+		{name: "uppercase", id: "AbC123", wantErr: false},
+		{name: "empty", id: "", wantErr: true},
+		{name: "dash", id: "abc-123", wantErr: true},
+		{name: "slash", id: "abc/123", wantErr: true},
+		{name: "underscore", id: "abc_123", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidContainerID(tc.id)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected an error for id %q", tc.id)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for id %q, got %v", tc.id, err)
+			}
+		})
+	}
+}

--- a/executor/containerid_test.go
+++ b/executor/containerid_test.go
@@ -19,6 +19,7 @@ func TestValidContainerID(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := ValidContainerID(tc.id)

--- a/executor/runcexecutor/executor.go
+++ b/executor/runcexecutor/executor.go
@@ -148,6 +148,13 @@ func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Ex
 func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, mounts []executor.Mount, process executor.ProcessInfo, started chan<- struct{}) (rec resourcestypes.Recorder, err error) {
 	meta := process.Meta
 
+	if id == "" {
+		id = identity.NewID()
+	}
+	if err := executor.ValidContainerID(id); err != nil {
+		return nil, err
+	}
+
 	startedOnce := sync.Once{}
 	done := make(chan error, 1)
 	w.mu.Lock()
@@ -211,9 +218,6 @@ func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, 
 		defer release()
 	}
 
-	if id == "" {
-		id = identity.NewID()
-	}
 	bundle := filepath.Join(w.root, id)
 
 	if err := os.Mkdir(bundle, 0o711); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3
 	github.com/containerd/typeurl/v2 v2.1.1
 	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/docker/cli v24.0.4+incompatible
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker v24.0.0-rc.2.0.20230718135204-8e51b8b59cb8+incompatible // master (v25.0.0-dev)
@@ -121,7 +122,6 @@ require (
 	github.com/containerd/ttrpc v1.2.2 // indirect
 	github.com/containernetworking/cni v1.1.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/hack/dockerfiles/doctoc.Dockerfile
+++ b/hack/dockerfiles/doctoc.Dockerfile
@@ -7,7 +7,11 @@ RUN apk add --no-cache git
 WORKDIR /src
 
 FROM base AS doctoc
-RUN npm install -g doctoc
+
+# DOCTOC_VERSION is the version of doctoc to install
+# see https://github.com/thlorenz/doctoc/tags for available releases.
+ARG DOCTOC_VERSION=v2.3.0
+RUN npm install -g doctoc@${DOCTOC_VERSION#v}
 RUN --mount=type=bind,source=README.md,target=README.md,rw <<EOT
   set -e
   doctoc README.md

--- a/hack/dockerfiles/generated-files.Dockerfile
+++ b/hack/dockerfiles/generated-files.Dockerfile
@@ -4,7 +4,7 @@ ARG GO_VERSION="1.20"
 ARG PROTOC_VERSION="3.11.4"
 
 # protoc is dynamically linked to glibc so can't use alpine base
-FROM golang:${GO_VERSION}-buster AS base
+FROM golang:${GO_VERSION}-bullseye AS base
 RUN apt-get update && apt-get --no-install-recommends install -y git unzip
 ARG PROTOC_VERSION
 ARG TARGETOS

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -486,7 +486,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		}
 	}()
 
-	subdir := path.Clean(gs.src.Subdir)
+	subdir := path.Join("/", gs.src.Subdir)
 	if subdir == "/" {
 		subdir = "."
 	}
@@ -559,6 +559,10 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 			return nil, errors.Wrapf(err, "failed to checkout remote %s", urlutil.RedactCredentials(gs.src.Remote))
 		}
 		if subdir != "." {
+			subdir = filepath.FromSlash(subdir)
+			if err := validateDirsOnly(cd, subdir); err != nil {
+				return nil, errors.Wrapf(err, "invalid subdir %v", subdir)
+			}
 			d, err := os.Open(filepath.Join(cd, subdir))
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to open subdir %v", subdir)
@@ -761,4 +765,26 @@ func (md cacheRefMetadata) setGitSnapshot(key string) error {
 
 func (md cacheRefMetadata) setGitRemote(key string) error {
 	return md.SetString(keyGitRemote, key, gitRemoteIndex+key)
+}
+
+// validateDirsOnly checks that each path component of subpath within root is a
+// real directory (not a symlink or file), preventing traversal and symlink escapes.
+func validateDirsOnly(root string, subpath string) error {
+	rel := filepath.Clean(subpath)
+	rel = strings.TrimPrefix(rel, string(filepath.Separator))
+	if rel == "" || rel == "." {
+		return nil
+	}
+	p := ""
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		p = filepath.Join(p, part)
+		fi, err := os.Lstat(filepath.Join(root, p))
+		if err != nil {
+			return errors.Wrapf(err, "failed to lstat %q", p)
+		}
+		if !fi.IsDir() {
+			return errors.Errorf("git subpath %q contains non-directory %q", subpath, p)
+		}
+	}
+	return nil
 }

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -345,7 +345,7 @@ func (gs *gitSourceHandler) CacheKey(ctx context.Context, g session.Group, index
 
 	// TODO: should we assume that remote tag is immutable? add a timer?
 
-	buf, err := gitWithinDir(ctx, gitDir, "", sock, knownHosts, gs.auth, "ls-remote", "origin", ref)
+	buf, err := gitWithinDir(ctx, gitDir, "", sock, knownHosts, gs.auth, "ls-remote", "--", "origin", ref)
 	if err != nil {
 		return "", "", nil, false, errors.Wrapf(err, "failed to fetch remote %s", urlutil.RedactCredentials(remote))
 	}
@@ -427,7 +427,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 	doFetch := true
 	if isCommitSHA(ref) {
 		// skip fetch if commit already exists
-		if _, err := gitWithinDir(ctx, gitDir, "", sock, knownHosts, nil, "cat-file", "-e", ref+"^{commit}"); err == nil {
+		if _, err := gitWithinDir(ctx, gitDir, "", sock, knownHosts, nil, "cat-file", "-e", "--", ref+"^{commit}"); err == nil {
 			doFetch = false
 		}
 	}
@@ -446,7 +446,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		}
 		args = append(args, "origin")
 		if !isCommitSHA(ref) {
-			args = append(args, "--force", ref+":tags/"+ref)
+			args = append(args, "--force", "--", ref+":tags/"+ref)
 			// local refs are needed so they would be advertised on next fetches. Force is used
 			// in case the ref is a branch and it now points to a different commit sha
 			// TODO: is there a better way to do this?
@@ -526,7 +526,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		} else {
 			pullref += ":" + pullref
 		}
-		_, err = gitWithinDir(ctx, checkoutDirGit, "", sock, knownHosts, gs.auth, "fetch", "-u", "--depth=1", "origin", pullref)
+		_, err = gitWithinDir(ctx, checkoutDirGit, "", sock, knownHosts, gs.auth, "fetch", "-u", "--depth=1", "--", "origin", pullref)
 		if err != nil {
 			return nil, err
 		}

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -560,10 +560,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 		}
 		if subdir != "." {
 			subdir = filepath.FromSlash(subdir)
-			if err := validateDirsOnly(cd, subdir); err != nil {
-				return nil, errors.Wrapf(err, "invalid subdir %v", subdir)
-			}
-			d, err := os.Open(filepath.Join(cd, subdir))
+			d, err := openSubdirSafe(cd, subdir)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to open subdir %v", subdir)
 			}
@@ -572,7 +569,7 @@ func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out 
 					d.Close()
 				}
 			}()
-			names, err := d.Readdirnames(0)
+			names, err := readdirnames(d)
 			if err != nil {
 				return nil, err
 			}
@@ -767,24 +764,3 @@ func (md cacheRefMetadata) setGitRemote(key string) error {
 	return md.SetString(keyGitRemote, key, gitRemoteIndex+key)
 }
 
-// validateDirsOnly checks that each path component of subpath within root is a
-// real directory (not a symlink or file), preventing traversal and symlink escapes.
-func validateDirsOnly(root string, subpath string) error {
-	rel := filepath.Clean(subpath)
-	rel = strings.TrimPrefix(rel, string(filepath.Separator))
-	if rel == "" || rel == "." {
-		return nil
-	}
-	p := ""
-	for _, part := range strings.Split(rel, string(filepath.Separator)) {
-		p = filepath.Join(p, part)
-		fi, err := os.Lstat(filepath.Join(root, p))
-		if err != nil {
-			return errors.Wrapf(err, "failed to lstat %q", p)
-		}
-		if !fi.IsDir() {
-			return errors.Errorf("git subpath %q contains non-directory %q", subpath, p)
-		}
-	}
-	return nil
-}

--- a/source/git/gitsource.go
+++ b/source/git/gitsource.go
@@ -763,4 +763,3 @@ func (md cacheRefMetadata) setGitSnapshot(key string) error {
 func (md cacheRefMetadata) setGitRemote(key string) error {
 	return md.SetString(keyGitRemote, key, gitRemoteIndex+key)
 }
-

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -712,11 +712,12 @@ func TestValidateDirsOnly(t *testing.T) {
 		tt := tt
 		t.Run(tt.subpath, func(t *testing.T) {
 			t.Parallel()
-			err := validateDirsOnly(root, tt.subpath)
+			f, err := openSubdirSafe(root, tt.subpath)
 			if tt.wantErr {
 				require.Error(t, err, "subpath %q should be rejected", tt.subpath)
 			} else {
 				require.NoError(t, err, "subpath %q should be accepted", tt.subpath)
+				f.Close()
 			}
 		})
 	}

--- a/source/git/gitsource_test.go
+++ b/source/git/gitsource_test.go
@@ -683,3 +683,41 @@ func logProgressStreams(ctx context.Context, t *testing.T) context.Context {
 	}()
 	return ctx
 }
+
+// TestValidateDirsOnly verifies that subdir path traversal and symlink escapes
+// are blocked (CVE-2026-33748).
+func TestValidateDirsOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not applicable on windows")
+	}
+	t.Parallel()
+	root := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "real", "nested"), 0o755))
+	require.NoError(t, os.Symlink("/tmp", filepath.Join(root, "escape")))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "file.txt"), []byte("x"), 0o644))
+
+	tests := []struct {
+		subpath string
+		wantErr bool
+	}{
+		{subpath: "real", wantErr: false},
+		{subpath: "real/nested", wantErr: false},
+		{subpath: "/real/nested", wantErr: false},
+		{subpath: "escape", wantErr: true},
+		{subpath: "file.txt", wantErr: true},
+		{subpath: "nonexistent", wantErr: true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.subpath, func(t *testing.T) {
+			t.Parallel()
+			err := validateDirsOnly(root, tt.subpath)
+			if tt.wantErr {
+				require.Error(t, err, "subpath %q should be rejected", tt.subpath)
+			} else {
+				require.NoError(t, err, "subpath %q should be accepted", tt.subpath)
+			}
+		})
+	}
+}

--- a/source/git/gitsource_unix.go
+++ b/source/git/gitsource_unix.go
@@ -5,13 +5,61 @@ package git
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
+
+// openSubdirSafe opens a subdirectory safely inside root.
+// Linux/Unix version uses openat+O_NOFOLLOW per component to eliminate TOCTOU races.
+// Returns a *os.File for the subdirectory.
+func openSubdirSafe(root string, subpath string) (*os.File, error) {
+	dirfd, err := unix.Open(root, unix.O_DIRECTORY|unix.O_PATH, 0)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open root %q", root)
+	}
+
+	rel := filepath.Clean(subpath)
+	rel = strings.TrimPrefix(rel, string(filepath.Separator))
+	if rel == "" || rel == "." {
+		return os.NewFile(uintptr(dirfd), root), nil
+	}
+
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		nextfd, err := unix.Openat(
+			dirfd,
+			part,
+			unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_PATH,
+			0,
+		)
+		unix.Close(dirfd)
+		if err != nil {
+			return nil, errors.Wrapf(err, "subpath %q: failed to open component %q", subpath, part)
+		}
+		dirfd = nextfd
+	}
+
+	return os.NewFile(uintptr(dirfd), filepath.Join(root, subpath)), nil
+}
+
+// readdirnames returns the names of entries in the directory represented by f.
+// On Unix, f may be an O_PATH fd; a readable fd is opened via Openat before reading.
+func readdirnames(f *os.File) ([]string, error) {
+	readfd, err := unix.Openat(int(f.Fd()), ".", unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open directory for reading")
+	}
+	d := os.NewFile(uintptr(readfd), f.Name())
+	defer d.Close()
+	return d.Readdirnames(0)
+}
 
 func runWithStandardUmask(ctx context.Context, cmd *exec.Cmd) error {
 	errCh := make(chan error)

--- a/source/git/gitsource_unix_test.go
+++ b/source/git/gitsource_unix_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+// +build !windows
+
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReaddirnames verifies that readdirnames correctly lists directory entries
+// from an O_PATH fd returned by openSubdirSafe.
+func TestReaddirnames(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sub", "a.txt"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sub", "b.txt"), []byte("b"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "sub", "child"), 0o755))
+
+	f, err := openSubdirSafe(root, "sub")
+	require.NoError(t, err)
+	defer f.Close()
+
+	names, err := readdirnames(f)
+	require.NoError(t, err)
+
+	sort.Strings(names)
+	require.Equal(t, []string{"a.txt", "b.txt", "child"}, names)
+}

--- a/source/git/gitsource_windows.go
+++ b/source/git/gitsource_windows.go
@@ -5,8 +5,39 @@ package git
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
 )
+
+// openSubdirSafe on Windows falls back to os.Lstat-based validation since
+// unix.Openat is not available.
+func openSubdirSafe(root string, subpath string) (*os.File, error) {
+	rel := filepath.Clean(subpath)
+	rel = strings.TrimPrefix(rel, string(filepath.Separator))
+	if rel != "" && rel != "." {
+		p := ""
+		for _, part := range strings.Split(rel, string(filepath.Separator)) {
+			p = filepath.Join(p, part)
+			fi, err := os.Lstat(filepath.Join(root, p))
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to lstat %q", p)
+			}
+			if !fi.IsDir() {
+				return nil, errors.Errorf("git subpath %q contains non-directory %q", subpath, p)
+			}
+		}
+	}
+	return os.Open(filepath.Join(root, subpath))
+}
+
+// readdirnames on Windows uses a normal readable fd returned by openSubdirSafe.
+func readdirnames(f *os.File) ([]string, error) {
+	return f.Readdirnames(0)
+}
 
 func runWithStandardUmask(ctx context.Context, cmd *exec.Cmd) error {
 	if err := cmd.Start(); err != nil {

--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -7,6 +7,7 @@ import (
 
 	srctypes "github.com/moby/buildkit/source/types"
 	"github.com/moby/buildkit/util/sshutil"
+	"github.com/pkg/errors"
 )
 
 type GitIdentifier struct {
@@ -50,7 +51,19 @@ func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 	if sd := path.Clean(repo.Subdir); sd == "/" || sd == "." {
 		repo.Subdir = ""
 	}
+	if err := validateGitRef(repo.Ref); err != nil {
+		return nil, err
+	}
 	return &repo, nil
+}
+
+// validateGitRef rejects refs that start with '-', which could be
+// interpreted as option flags by git commands.
+func validateGitRef(ref string) error {
+	if strings.HasPrefix(ref, "-") {
+		return errors.Errorf("invalid git ref %q", ref)
+	}
+	return nil
 }
 
 func (i *GitIdentifier) ID() string {

--- a/source/gitidentifier.go
+++ b/source/gitidentifier.go
@@ -48,9 +48,7 @@ func NewGitIdentifier(remoteURL string) (*GitIdentifier, error) {
 		u.Fragment = ""
 		repo.Remote = u.String()
 	}
-	if sd := path.Clean(repo.Subdir); sd == "/" || sd == "." {
-		repo.Subdir = ""
-	}
+	repo.Subdir = strings.TrimPrefix(path.Join("/", repo.Subdir), "/")
 	if err := validateGitRef(repo.Ref); err != nil {
 		return nil, err
 	}

--- a/source/gitidentifier_test.go
+++ b/source/gitidentifier_test.go
@@ -48,14 +48,14 @@ func TestNewGitIdentifier(t *testing.T) {
 			expected: GitIdentifier{
 				Remote: "git://github.com/user/repo.git",
 				Ref:    "mybranch",
-				Subdir: "mydir/mysubdir/",
+				Subdir: "mydir/mysubdir",
 			},
 		},
 		{
 			url: "git://github.com/user/repo.git#:mydir/mysubdir/",
 			expected: GitIdentifier{
 				Remote: "git://github.com/user/repo.git",
-				Subdir: "mydir/mysubdir/",
+				Subdir: "mydir/mysubdir",
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestNewGitIdentifier(t *testing.T) {
 			expected: GitIdentifier{
 				Remote: "https://github.com/user/repo.git",
 				Ref:    "mybranch",
-				Subdir: "mydir/mysubdir/",
+				Subdir: "mydir/mysubdir",
 			},
 		},
 		{
@@ -83,7 +83,7 @@ func TestNewGitIdentifier(t *testing.T) {
 			expected: GitIdentifier{
 				Remote: "git@github.com:user/repo.git",
 				Ref:    "mybranch",
-				Subdir: "mydir/mysubdir/",
+				Subdir: "mydir/mysubdir",
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func TestNewGitIdentifier(t *testing.T) {
 			expected: GitIdentifier{
 				Remote: "ssh://github.com/user/repo.git",
 				Ref:    "mybranch",
-				Subdir: "mydir/mysubdir/",
+				Subdir: "mydir/mysubdir",
 			},
 		},
 		{
@@ -105,7 +105,70 @@ func TestNewGitIdentifier(t *testing.T) {
 			expected: GitIdentifier{
 				Remote: "ssh://foo%40barcorp.com@github.com/user/repo.git",
 				Ref:    "mybranch",
-				Subdir: "mydir/mysubdir/",
+				Subdir: "mydir/mysubdir",
+			},
+		},
+		{
+			url: "https://github.com/user/repo.git#main:../../escape",
+			expected: GitIdentifier{
+				Remote: "https://github.com/user/repo.git",
+				Ref:    "main",
+				Subdir: "escape",
+			},
+		},
+		{
+			url: "https://github.com/user/repo.git#main:dir/../../escape",
+			expected: GitIdentifier{
+				Remote: "https://github.com/user/repo.git",
+				Ref:    "main",
+				Subdir: "escape",
+			},
+		},
+		{
+			url: "https://github.com/user/repo.git#main:/absolute/path",
+			expected: GitIdentifier{
+				Remote: "https://github.com/user/repo.git",
+				Ref:    "main",
+				Subdir: "absolute/path",
+			},
+		},
+		{
+			url: "https://github.com/user/repo.git#main:../",
+			expected: GitIdentifier{
+				Remote: "https://github.com/user/repo.git",
+				Ref:    "main",
+			},
+		},
+		{
+			url: "ssh://github.com/user/repo.git#main:../../escape",
+			expected: GitIdentifier{
+				Remote: "ssh://github.com/user/repo.git",
+				Ref:    "main",
+				Subdir: "escape",
+			},
+		},
+		{
+			url: "ssh://github.com/user/repo.git#main:/absolute/path",
+			expected: GitIdentifier{
+				Remote: "ssh://github.com/user/repo.git",
+				Ref:    "main",
+				Subdir: "absolute/path",
+			},
+		},
+		{
+			url: "git@github.com:user/repo.git#main:../../escape",
+			expected: GitIdentifier{
+				Remote: "git@github.com:user/repo.git",
+				Ref:    "main",
+				Subdir: "escape",
+			},
+		},
+		{
+			url: "git@github.com:user/repo.git#main:/absolute/path",
+			expected: GitIdentifier{
+				Remote: "git@github.com:user/repo.git",
+				Ref:    "main",
+				Subdir: "absolute/path",
 			},
 		},
 	}

--- a/source/http/httpsource.go
+++ b/source/http/httpsource.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unicode"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/session"
@@ -289,7 +290,11 @@ func (hs *httpSourceHandler) save(ctx context.Context, resp *http.Response, s se
 	if hs.src.Perm != 0 {
 		perm = hs.src.Perm
 	}
-	fp := filepath.Join(dir, getFileName(hs.src.URL, hs.src.Filename, resp))
+	name := getFileName(hs.src.URL, hs.src.Filename, resp)
+	fp, err := securejoin.SecureJoin(dir, name)
+	if err != nil {
+		return nil, "", err
+	}
 
 	f, err := os.OpenFile(fp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(perm))
 	if err != nil {

--- a/source/http/httpsource.go
+++ b/source/http/httpsource.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/moby/buildkit/cache"
@@ -415,16 +416,30 @@ func (hs *httpSourceHandler) Snapshot(ctx context.Context, g session.Group) (cac
 	return ref, nil
 }
 
+func safeFileName(s string) string {
+	defaultName := "download"
+	name := filepath.Base(filepath.FromSlash(strings.TrimSpace(s)))
+	if name == "" || name == "." || name == ".." {
+		return defaultName
+	}
+	for _, r := range name {
+		if r == 0 || unicode.IsControl(r) {
+			return defaultName
+		}
+	}
+	return name
+}
+
 func getFileName(urlStr, manualFilename string, resp *http.Response) string {
 	if manualFilename != "" {
-		return manualFilename
+		return safeFileName(manualFilename)
 	}
 	if resp != nil {
 		if contentDisposition := resp.Header.Get("Content-Disposition"); contentDisposition != "" {
 			if _, params, err := mime.ParseMediaType(contentDisposition); err == nil {
 				if params["filename"] != "" && !strings.HasSuffix(params["filename"], "/") {
 					if filename := filepath.Base(filepath.FromSlash(params["filename"])); filename != "" {
-						return filename
+						return safeFileName(filename)
 					}
 				}
 			}
@@ -433,10 +448,10 @@ func getFileName(urlStr, manualFilename string, resp *http.Response) string {
 	u, err := url.Parse(urlStr)
 	if err == nil {
 		if base := path.Base(u.Path); base != "." && base != "/" {
-			return base
+			return safeFileName(base)
 		}
 	}
-	return "download"
+	return safeFileName("")
 }
 
 func searchHTTPURLDigest(ctx context.Context, store cache.MetadataStore, dgst digest.Digest) ([]cacheRefMetadata, error) {

--- a/source/http/httpsource_test.go
+++ b/source/http/httpsource_test.go
@@ -381,3 +381,47 @@ func newHTTPSource(t *testing.T) (source.Source, error) {
 		CacheAccessor: cm,
 	})
 }
+
+func TestSafeFileName(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name string
+		in   string
+		want string
+	}
+
+	tests := []testCase{
+		{name: "simple", in: "foo", want: "foo"},
+		{name: "simple_ext", in: "foo.txt", want: "foo.txt"},
+		{name: "unicode_cjk", in: "資料.txt", want: "資料.txt"},
+		{name: "unicode_cyrillic", in: "тест-файл", want: "тест-файл"},
+		{name: "spaces_allowed", in: "name with spaces.txt", want: "name with spaces.txt"},
+		{name: "trim_outer_whitespace", in: "  foo.txt  ", want: "foo.txt"},
+		{name: "unix_path", in: "a/b/c.txt", want: "c.txt"},
+		{name: "empty", in: "", want: "download"},
+		{name: "dot", in: ".", want: "download"},
+		{name: "dot_dot", in: "..", want: "download"},
+		{name: "traversal_unix", in: "../", want: "download"},
+		{name: "nul_byte", in: "a\x00b", want: "download"},
+		{name: "control", in: "a\nb", want: "download"},
+	}
+	if runtime.GOOS == "windows" {
+		tests = append(tests,
+			testCase{name: "windows_traversal", in: "..\\", want: "download"},
+			testCase{name: "windows_path_basename", in: "a\\b\\c.txt", want: "c.txt"},
+		)
+	} else {
+		tests = append(tests,
+			testCase{name: "windows_traversal_literal", in: "..\\", want: "..\\"},
+			testCase{name: "windows_path_literal", in: "a\\b\\c.txt", want: "a\\b\\c.txt"},
+		)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, safeFileName(tt.in))
+		})
+	}
+}

--- a/source/http/httpsource_test.go
+++ b/source/http/httpsource_test.go
@@ -419,6 +419,7 @@ func TestSafeFileName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.want, safeFileName(tt.in))


### PR DESCRIPTION
This PR backports the security fixes from https://github.com/moby/buildkit/releases/tag/v0.28.1 (PR https://github.com/moby/buildkit/pull/6613) to the v0.12 branch with Go 1.20-compatible implementations.

Fixes https://github.com/advisories/GHSA-4vrq-3vrq-g6gg and https://github.com/advisories/GHSA-4c29-8rgm-jvjj.